### PR TITLE
Updated dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the writing standards set by the [Proselint tool](http://proselint.com/).
 
 The source code in the submitted Java source code files must also pass
 additional tests set by the [GatorGrader
-tool](https://github.com/gatored/gatorgrader).
+tool](https://github.com/GatorEducator/gatorgrader).
 
 When you use the `git commit` command to transfer your source code to your
 GitHub repository, [Travis CI](https://travis-ci.com/) will initialize a build
@@ -187,10 +187,10 @@ assignment was developed for the following software and versions:
 <!-- UPDATE: update links to your starter repository and lab sheets repository -->
 
 If you have found a problem with this assignment's provided source code, then
-you can go to the [GatorGrader Sample Assignment](https://github.com/gatored/gatorgrader-samplelab)
+you can go to the [GatorGrader Sample Assignment](https://github.com/GatorEducator/java-assignment-starter-100-01)
 repository and create an issue by clicking the "Issues" tab and then clicking
 the green "New Issue" button. If you have found a problem with the [GatorGrader
-tool](https://github.com/gatored/gatorgrader) and the way that it checks your
+tool](https://github.com/GatorEducator/gatorgrader) and the way that it checks your
 assignment, then you can follow the aforementioned steps to create an issue in
 its repository. To ensure that your issue is properly resolved, please provide
 as many details as is possible about the problem that you experienced. If you


### PR DESCRIPTION
Fixes #1

It seems gatored moved to GatorEducator. Also, it seems `gatorgrader-samplelab` was renamed to `java-assignment-starter-100-01`